### PR TITLE
feat(http_status): Add methods to check HTTP status code ranges

### DIFF
--- a/lib/src/http_status.dart
+++ b/lib/src/http_status.dart
@@ -4,6 +4,7 @@
 // is governed by a BSD-style license that can be found in the LICENSE file.
 
 import 'http_status_code.dart';
+import 'utils/int_http_status_code_extension.dart';
 
 /// Each [HttpStatusCode] is described below, including a description of which
 /// method(s) it can follow and any metainformation required in the response.
@@ -2792,6 +2793,21 @@ class HttpStatus {
     HttpStatusCode.networkConnectTimeoutError:
         HttpStatus.code599NetworkConnectTimeoutError,
   };
+
+  /// Returns true if this ranges between 100 and 199
+  bool get isInformationHttpStatusCode => code.isInformationHttpStatusCode;
+
+  /// Returns true if code ranges between 200 and 299
+  bool get isSuccessfulHttpStatusCode => code.isSuccessfulHttpStatusCode;
+
+  /// Returns true if this ranges between 300 and 399
+  bool get isRedirectHttpStatusCode => code.isRedirectHttpStatusCode;
+
+  /// Returns true if this ranges between 400 and 499
+  bool get isClientErrorHttpStatusCode => code.isClientErrorHttpStatusCode;
+
+  /// Returns true if code ranges between 500 and 599
+  bool get isServerErrorHttpStatusCode => code.isServerErrorHttpStatusCode;
 
   @override
   int get hashCode => _equality().hashCode;

--- a/test/src/http_status_test.dart
+++ b/test/src/http_status_test.dart
@@ -18,6 +18,11 @@ void main() {
             equals('Client should continue with request.'),
           );
           expect(HttpStatus.code100Continue, HttpStatus.continue_);
+          expect(HttpStatus.continue_.isInformationHttpStatusCode, isTrue);
+          expect(HttpStatus.continue_.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.continue_.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.continue_.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.continue_.isServerErrorHttpStatusCode, isFalse);
         });
         test('101 Switching Protocol', () {
           expect(
@@ -36,6 +41,26 @@ void main() {
             HttpStatus.code101SwitchingProtocols,
             HttpStatus.switchingProtocols,
           );
+          expect(
+            HttpStatus.switchingProtocols.isInformationHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.switchingProtocols.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.switchingProtocols.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.switchingProtocols.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.switchingProtocols.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('102 Processing', () {
           expect(
@@ -48,6 +73,11 @@ void main() {
             equals('Server has received and is processing the request.'),
           );
           expect(HttpStatus.code102Processing, HttpStatus.processing);
+          expect(HttpStatus.processing.isInformationHttpStatusCode, isTrue);
+          expect(HttpStatus.processing.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.processing.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.processing.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.processing.isServerErrorHttpStatusCode, isFalse);
         });
         test('103 Early Hints', () {
           expect(
@@ -63,6 +93,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code103EarlyHints, HttpStatus.earlyHints);
+          expect(HttpStatus.earlyHints.isInformationHttpStatusCode, isTrue);
+          expect(HttpStatus.earlyHints.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.earlyHints.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.earlyHints.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.earlyHints.isServerErrorHttpStatusCode, isFalse);
         });
       });
       group('2xx Success -', () {
@@ -74,6 +109,11 @@ void main() {
             equals('The request was fulfilled.'),
           );
           expect(HttpStatus.code200Ok, HttpStatus.ok);
+          expect(HttpStatus.ok.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.ok.isSuccessfulHttpStatusCode, isTrue);
+          expect(HttpStatus.ok.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.ok.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.ok.isServerErrorHttpStatusCode, isFalse);
         });
         test('201 Created', () {
           expect(HttpStatus.created.code, equals(HttpStatusCode.created));
@@ -86,6 +126,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code201Created, HttpStatus.created);
+          expect(HttpStatus.created.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.created.isSuccessfulHttpStatusCode, isTrue);
+          expect(HttpStatus.created.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.created.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.created.isServerErrorHttpStatusCode, isFalse);
         });
         test('202 Accepted', () {
           expect(HttpStatus.accepted.code, equals(HttpStatusCode.accepted));
@@ -100,6 +145,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code202Accepted, HttpStatus.accepted);
+          expect(HttpStatus.accepted.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.accepted.isSuccessfulHttpStatusCode, isTrue);
+          expect(HttpStatus.accepted.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.accepted.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.accepted.isServerErrorHttpStatusCode, isFalse);
         });
         test('203 Non-authoritative Information', () {
           expect(
@@ -122,6 +172,26 @@ void main() {
             HttpStatus.code203NonAuthoritativeInformation,
             HttpStatus.nonAuthoritativeInformation,
           );
+          expect(
+            HttpStatus.nonAuthoritativeInformation.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.nonAuthoritativeInformation.isSuccessfulHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.nonAuthoritativeInformation.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.nonAuthoritativeInformation.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.nonAuthoritativeInformation.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('204 No Content', () {
           expect(HttpStatus.noContent.code, equals(HttpStatusCode.noContent));
@@ -135,6 +205,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code204NoContent, HttpStatus.noContent);
+          expect(HttpStatus.noContent.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.noContent.isSuccessfulHttpStatusCode, isTrue);
+          expect(HttpStatus.noContent.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.noContent.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.noContent.isServerErrorHttpStatusCode, isFalse);
         });
         test('205 Reset Content', () {
           expect(
@@ -152,6 +227,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code205ResetContent, HttpStatus.resetContent);
+          expect(HttpStatus.resetContent.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.resetContent.isSuccessfulHttpStatusCode, isTrue);
+          expect(HttpStatus.resetContent.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.resetContent.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.resetContent.isServerErrorHttpStatusCode, isFalse);
         });
         test('206 Partial Content', () {
           expect(
@@ -170,6 +250,20 @@ void main() {
             ),
           );
           expect(HttpStatus.code206PartialContent, HttpStatus.partialContent);
+          expect(
+            HttpStatus.partialContent.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.partialContent.isSuccessfulHttpStatusCode, isTrue);
+          expect(HttpStatus.partialContent.isRedirectHttpStatusCode, isFalse);
+          expect(
+            HttpStatus.partialContent.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.partialContent.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('207 Multi-Status', () {
           expect(
@@ -186,6 +280,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code207MultiStatus, HttpStatus.multiStatus);
+          expect(HttpStatus.multiStatus.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.multiStatus.isSuccessfulHttpStatusCode, isTrue);
+          expect(HttpStatus.multiStatus.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.multiStatus.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.multiStatus.isServerErrorHttpStatusCode, isFalse);
         });
         test('208 Already Reported', () {
           expect(
@@ -205,6 +304,20 @@ void main() {
             HttpStatus.code208AlreadyReported,
             HttpStatus.alreadyReported,
           );
+          expect(
+            HttpStatus.alreadyReported.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.alreadyReported.isSuccessfulHttpStatusCode, isTrue);
+          expect(HttpStatus.alreadyReported.isRedirectHttpStatusCode, isFalse);
+          expect(
+            HttpStatus.alreadyReported.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.alreadyReported.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('226 IM Used', () {
           expect(HttpStatus.imUsed.code, equals(HttpStatusCode.imUsed));
@@ -219,9 +332,14 @@ void main() {
             ),
           );
           expect(HttpStatus.code226ImUsed, HttpStatus.imUsed);
+          expect(HttpStatus.imUsed.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.imUsed.isSuccessfulHttpStatusCode, isTrue);
+          expect(HttpStatus.imUsed.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.imUsed.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.imUsed.isServerErrorHttpStatusCode, isFalse);
         });
       });
-      group('3xx Redirection-', () {
+      group('3xx Redirection -', () {
         test('300 Multiple Choices', () {
           expect(
             HttpStatus.multipleChoices.code,
@@ -242,6 +360,23 @@ void main() {
           expect(
             HttpStatus.code300MultipleChoices,
             HttpStatus.multipleChoices,
+          );
+          expect(
+            HttpStatus.multipleChoices.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.multipleChoices.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.multipleChoices.isRedirectHttpStatusCode, isTrue);
+          expect(
+            HttpStatus.multipleChoices.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.multipleChoices.isServerErrorHttpStatusCode,
+            isFalse,
           );
         });
         test('301 Moved Permanently', () {
@@ -265,6 +400,23 @@ void main() {
             HttpStatus.code301MovedPermanently,
             HttpStatus.movedPermanently,
           );
+          expect(
+            HttpStatus.movedPermanently.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.movedPermanently.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.movedPermanently.isRedirectHttpStatusCode, isTrue);
+          expect(
+            HttpStatus.movedPermanently.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.movedPermanently.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('302 Found', () {
           expect(HttpStatus.found.code, equals(HttpStatusCode.found));
@@ -280,6 +432,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code302Found, HttpStatus.found);
+          expect(HttpStatus.found.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.found.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.found.isRedirectHttpStatusCode, isTrue);
+          expect(HttpStatus.found.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.found.isServerErrorHttpStatusCode, isFalse);
         });
         test('302 Moved Temporarily', () {
           expect(
@@ -304,6 +461,23 @@ void main() {
             HttpStatus.code302MovedTemporarily,
             HttpStatus.movedTemporarily,
           );
+          expect(
+            HttpStatus.movedTemporarily.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.movedTemporarily.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.movedTemporarily.isRedirectHttpStatusCode, isTrue);
+          expect(
+            HttpStatus.movedTemporarily.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.movedTemporarily.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('303 See Other', () {
           expect(HttpStatus.seeOther.code, equals(HttpStatusCode.seeOther));
@@ -318,6 +492,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code303SeeOther, HttpStatus.seeOther);
+          expect(HttpStatus.seeOther.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.seeOther.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.seeOther.isRedirectHttpStatusCode, isTrue);
+          expect(HttpStatus.seeOther.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.seeOther.isServerErrorHttpStatusCode, isFalse);
         });
         test('305 Not Modified', () {
           expect(
@@ -334,6 +513,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code305NotModified, HttpStatus.notModified);
+          expect(HttpStatus.notModified.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.notModified.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.notModified.isRedirectHttpStatusCode, isTrue);
+          expect(HttpStatus.notModified.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.notModified.isServerErrorHttpStatusCode, isFalse);
         });
         test('305 Use Proxy', () {
           expect(HttpStatus.useProxy.code, equals(HttpStatusCode.useProxy));
@@ -347,6 +531,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code305UseProxy, HttpStatus.useProxy);
+          expect(HttpStatus.useProxy.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.useProxy.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.useProxy.isRedirectHttpStatusCode, isTrue);
+          expect(HttpStatus.useProxy.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.useProxy.isServerErrorHttpStatusCode, isFalse);
         });
         test('307 Temporary Redirect', () {
           expect(
@@ -368,6 +557,23 @@ void main() {
           expect(
             HttpStatus.code307TemporaryRedirect,
             HttpStatus.temporaryRedirect,
+          );
+          expect(
+            HttpStatus.temporaryRedirect.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.temporaryRedirect.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.temporaryRedirect.isRedirectHttpStatusCode, isTrue);
+          expect(
+            HttpStatus.temporaryRedirect.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.temporaryRedirect.isServerErrorHttpStatusCode,
+            isFalse,
           );
         });
         test('308 Permanent Redirect', () {
@@ -391,9 +597,26 @@ void main() {
             HttpStatus.code308PermanentRedirect,
             HttpStatus.permanentRedirect,
           );
+          expect(
+            HttpStatus.permanentRedirect.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.permanentRedirect.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.permanentRedirect.isRedirectHttpStatusCode, isTrue);
+          expect(
+            HttpStatus.permanentRedirect.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.permanentRedirect.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
       });
-      group('4xx Client Error-', () {
+      group('4xx Client Error -', () {
         test('400 Bad Request', () {
           expect(
             HttpStatus.badRequest.code,
@@ -410,6 +633,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code400BadRequest, HttpStatus.badRequest);
+          expect(HttpStatus.badRequest.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.badRequest.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.badRequest.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.badRequest.isClientErrorHttpStatusCode, isTrue);
+          expect(HttpStatus.badRequest.isServerErrorHttpStatusCode, isFalse);
         });
         test('401 Unauthorized', () {
           expect(
@@ -425,6 +653,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code401Unauthorized, HttpStatus.unauthorized);
+          expect(HttpStatus.unauthorized.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.unauthorized.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.unauthorized.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.unauthorized.isClientErrorHttpStatusCode, isTrue);
+          expect(HttpStatus.unauthorized.isServerErrorHttpStatusCode, isFalse);
         });
         test('402 Payment Required', () {
           expect(
@@ -440,6 +673,23 @@ void main() {
             HttpStatus.code402PaymentRequired,
             HttpStatus.paymentRequired,
           );
+          expect(
+            HttpStatus.paymentRequired.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.paymentRequired.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.paymentRequired.isRedirectHttpStatusCode, isFalse);
+          expect(
+            HttpStatus.paymentRequired.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.paymentRequired.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('403 Forbidden', () {
           expect(HttpStatus.forbidden.code, equals(HttpStatusCode.forbidden));
@@ -452,6 +702,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code403Forbidden, HttpStatus.forbidden);
+          expect(HttpStatus.forbidden.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.forbidden.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.forbidden.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.forbidden.isClientErrorHttpStatusCode, isTrue);
+          expect(HttpStatus.forbidden.isServerErrorHttpStatusCode, isFalse);
         });
         test('404 Not Found', () {
           expect(HttpStatus.notFound.code, equals(HttpStatusCode.notFound));
@@ -465,6 +720,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code404NotFound, HttpStatus.notFound);
+          expect(HttpStatus.notFound.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.notFound.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.notFound.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.notFound.isClientErrorHttpStatusCode, isTrue);
+          expect(HttpStatus.notFound.isServerErrorHttpStatusCode, isFalse);
         });
         test('405 Method Not Allowed', () {
           expect(
@@ -486,6 +746,23 @@ void main() {
             HttpStatus.code405MethodNotAllowed,
             HttpStatus.methodNotAllowed,
           );
+          expect(
+            HttpStatus.methodNotAllowed.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.methodNotAllowed.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.methodNotAllowed.isRedirectHttpStatusCode, isFalse);
+          expect(
+            HttpStatus.methodNotAllowed.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.methodNotAllowed.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('406 Not Acceptable', () {
           expect(
@@ -504,6 +781,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code406NotAcceptable, HttpStatus.notAcceptable);
+          expect(HttpStatus.notAcceptable.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.notAcceptable.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.notAcceptable.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.notAcceptable.isClientErrorHttpStatusCode, isTrue);
+          expect(HttpStatus.notAcceptable.isServerErrorHttpStatusCode, isFalse);
         });
         test('407 Proxy Authentication Required', () {
           expect(
@@ -525,6 +807,26 @@ void main() {
             HttpStatus.code407ProxyAuthenticationRequired,
             HttpStatus.proxyAuthenticationRequired,
           );
+          expect(
+            HttpStatus.proxyAuthenticationRequired.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.proxyAuthenticationRequired.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.proxyAuthenticationRequired.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.proxyAuthenticationRequired.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.proxyAuthenticationRequired.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('408 Request Timeout', () {
           expect(
@@ -540,6 +842,17 @@ void main() {
             ),
           );
           expect(HttpStatus.code408RequestTimeout, HttpStatus.requestTimeout);
+          expect(
+            HttpStatus.requestTimeout.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.requestTimeout.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.requestTimeout.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.requestTimeout.isClientErrorHttpStatusCode, isTrue);
+          expect(
+            HttpStatus.requestTimeout.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('409 Conflict', () {
           expect(HttpStatus.conflict.code, equals(HttpStatusCode.conflict));
@@ -554,6 +867,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code409Conflict, HttpStatus.conflict);
+          expect(HttpStatus.conflict.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.conflict.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.conflict.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.conflict.isClientErrorHttpStatusCode, isTrue);
+          expect(HttpStatus.conflict.isServerErrorHttpStatusCode, isFalse);
         });
         test('410 Gone', () {
           expect(HttpStatus.gone.code, equals(HttpStatusCode.gone));
@@ -566,6 +884,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code410Gone, HttpStatus.gone);
+          expect(HttpStatus.gone.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.gone.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.gone.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.gone.isClientErrorHttpStatusCode, isTrue);
+          expect(HttpStatus.gone.isServerErrorHttpStatusCode, isFalse);
         });
         test('411 Length Required', () {
           expect(
@@ -581,6 +904,17 @@ void main() {
             ),
           );
           expect(HttpStatus.code411LengthRequired, HttpStatus.lengthRequired);
+          expect(
+            HttpStatus.lengthRequired.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.lengthRequired.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.lengthRequired.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.lengthRequired.isClientErrorHttpStatusCode, isTrue);
+          expect(
+            HttpStatus.lengthRequired.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('412 Precondition Failed', () {
           expect(
@@ -601,6 +935,26 @@ void main() {
           expect(
             HttpStatus.code412PreconditionFailed,
             HttpStatus.preconditionFailed,
+          );
+          expect(
+            HttpStatus.preconditionFailed.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.preconditionFailed.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.preconditionFailed.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.preconditionFailed.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.preconditionFailed.isServerErrorHttpStatusCode,
+            isFalse,
           );
         });
         test('413 Payload Too Large', () {
@@ -624,6 +978,26 @@ void main() {
             HttpStatus.code413RequestEntityTooLarge,
             HttpStatus.requestEntityTooLarge,
           );
+          expect(
+            HttpStatus.requestEntityTooLarge.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestEntityTooLarge.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestEntityTooLarge.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestEntityTooLarge.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.requestEntityTooLarge.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('414 Request-URI Too Long', () {
           expect(
@@ -646,6 +1020,26 @@ void main() {
             HttpStatus.code414RequestUriTooLong,
             HttpStatus.requestUriTooLong,
           );
+          expect(
+            HttpStatus.requestUriTooLong.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestUriTooLong.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestUriTooLong.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestUriTooLong.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.requestUriTooLong.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('415 Unsupported Media Type', () {
           expect(
@@ -667,6 +1061,26 @@ void main() {
           expect(
             HttpStatus.code415UnsupportedMediaType,
             HttpStatus.unsupportedMediaType,
+          );
+          expect(
+            HttpStatus.unsupportedMediaType.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.unsupportedMediaType.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.unsupportedMediaType.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.unsupportedMediaType.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.unsupportedMediaType.isServerErrorHttpStatusCode,
+            isFalse,
           );
         });
         test('416 Requested Range Not Satisfiable', () {
@@ -691,6 +1105,26 @@ void main() {
             HttpStatus.code416RequestedRangeNotSatisfiable,
             HttpStatus.requestedRangeNotSatisfiable,
           );
+          expect(
+            HttpStatus.requestedRangeNotSatisfiable.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestedRangeNotSatisfiable.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestedRangeNotSatisfiable.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestedRangeNotSatisfiable.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.requestedRangeNotSatisfiable.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('417 Expectation Failed', () {
           expect(
@@ -712,6 +1146,26 @@ void main() {
             HttpStatus.code417ExpectationFailed,
             HttpStatus.expectationFailed,
           );
+          expect(
+            HttpStatus.expectationFailed.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.expectationFailed.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.expectationFailed.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.expectationFailed.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.expectationFailed.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('418 I\'m A Teapot', () {
           expect(HttpStatus.imATeapot.code, equals(HttpStatusCode.imATeapot));
@@ -728,6 +1182,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code418ImATeapot, HttpStatus.imATeapot);
+          expect(HttpStatus.imATeapot.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.imATeapot.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.imATeapot.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.imATeapot.isClientErrorHttpStatusCode, isTrue);
+          expect(HttpStatus.imATeapot.isServerErrorHttpStatusCode, isFalse);
         });
         test('419 Insufficient Space On Resource', () {
           expect(
@@ -753,6 +1212,26 @@ void main() {
             HttpStatus.code419InsufficientSpaceOnResource,
             HttpStatus.insufficientSpaceOnResource,
           );
+          expect(
+            HttpStatus.insufficientSpaceOnResource.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.insufficientSpaceOnResource.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.insufficientSpaceOnResource.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.insufficientSpaceOnResource.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.insufficientSpaceOnResource.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('420 Method Failure', () {
           expect(
@@ -772,6 +1251,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code420MethodFailure, HttpStatus.methodFailure);
+          expect(HttpStatus.methodFailure.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.methodFailure.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.methodFailure.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.methodFailure.isClientErrorHttpStatusCode, isTrue);
+          expect(HttpStatus.methodFailure.isServerErrorHttpStatusCode, isFalse);
         });
         test('421 Misdirected Request', () {
           expect(
@@ -794,6 +1278,26 @@ void main() {
           expect(
             HttpStatus.code421MisdirectedRequest,
             HttpStatus.misdirectedRequest,
+          );
+          expect(
+            HttpStatus.misdirectedRequest.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.misdirectedRequest.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.misdirectedRequest.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.misdirectedRequest.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.misdirectedRequest.isServerErrorHttpStatusCode,
+            isFalse,
           );
         });
         test('422 Unprocessable Entity', () {
@@ -820,6 +1324,26 @@ void main() {
             HttpStatus.code422UnprocessableEntity,
             HttpStatus.unprocessableEntity,
           );
+          expect(
+            HttpStatus.unprocessableEntity.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.unprocessableEntity.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.unprocessableEntity.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.unprocessableEntity.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.unprocessableEntity.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('423 Locked', () {
           expect(HttpStatus.locked.code, equals(HttpStatusCode.locked));
@@ -831,6 +1355,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code423Locked, HttpStatus.locked);
+          expect(HttpStatus.locked.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.locked.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.locked.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.locked.isClientErrorHttpStatusCode, isTrue);
+          expect(HttpStatus.locked.isServerErrorHttpStatusCode, isFalse);
         });
         test('424 Failed Dependency', () {
           expect(
@@ -850,6 +1379,23 @@ void main() {
             HttpStatus.code424FailedDependency,
             HttpStatus.failedDependency,
           );
+          expect(
+            HttpStatus.failedDependency.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.failedDependency.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.failedDependency.isRedirectHttpStatusCode, isFalse);
+          expect(
+            HttpStatus.failedDependency.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.failedDependency.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('426 Upgrade Required', () {
           expect(
@@ -866,6 +1412,23 @@ void main() {
             ),
           );
           expect(HttpStatus.code426UpgradeRequired, HttpStatus.upgradeRequired);
+          expect(
+            HttpStatus.upgradeRequired.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.upgradeRequired.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.upgradeRequired.isRedirectHttpStatusCode, isFalse);
+          expect(
+            HttpStatus.upgradeRequired.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.upgradeRequired.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('428 Precondition Required', () {
           expect(
@@ -884,6 +1447,26 @@ void main() {
             HttpStatus.code428PreconditionRequired,
             HttpStatus.preconditionRequired,
           );
+          expect(
+            HttpStatus.preconditionRequired.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.preconditionRequired.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.preconditionRequired.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.preconditionRequired.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.preconditionRequired.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('429 Too Many Requests', () {
           expect(
@@ -899,6 +1482,23 @@ void main() {
             ),
           );
           expect(HttpStatus.code429TooManyRequests, HttpStatus.tooManyRequests);
+          expect(
+            HttpStatus.tooManyRequests.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.tooManyRequests.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.tooManyRequests.isRedirectHttpStatusCode, isFalse);
+          expect(
+            HttpStatus.tooManyRequests.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.tooManyRequests.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('431 Request Header Fields Too Large', () {
           expect(
@@ -922,6 +1522,26 @@ void main() {
             HttpStatus.code431RequestHeaderFieldsTooLarge,
             HttpStatus.requestHeaderFieldsTooLarge,
           );
+          expect(
+            HttpStatus.requestHeaderFieldsTooLarge.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestHeaderFieldsTooLarge.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestHeaderFieldsTooLarge.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.requestHeaderFieldsTooLarge.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.requestHeaderFieldsTooLarge.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('444 Connection Closed Without Response', () {
           expect(
@@ -944,6 +1564,30 @@ void main() {
             HttpStatus.code444ConnectionClosedWithoutResponse,
             HttpStatus.connectionClosedWithoutResponse,
           );
+          expect(
+            HttpStatus
+                .connectionClosedWithoutResponse.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus
+                .connectionClosedWithoutResponse.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.connectionClosedWithoutResponse.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus
+                .connectionClosedWithoutResponse.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus
+                .connectionClosedWithoutResponse.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
         test('451 Unavailable For Legal Reasons', () {
           expect(
@@ -965,8 +1609,28 @@ void main() {
             HttpStatus.code451UnavailableForLegalReasons,
             HttpStatus.unavailableForLegalReasons,
           );
+          expect(
+            HttpStatus.unavailableForLegalReasons.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.unavailableForLegalReasons.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.unavailableForLegalReasons.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.unavailableForLegalReasons.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.unavailableForLegalReasons.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
-        test('499 ', () {
+        test('499 Client Closed Request', () {
           expect(
             HttpStatus.clientClosedRequest.code,
             equals(HttpStatusCode.clientClosedRequest),
@@ -987,9 +1651,29 @@ void main() {
             HttpStatus.code499ClientClosedRequest,
             HttpStatus.clientClosedRequest,
           );
+          expect(
+            HttpStatus.clientClosedRequest.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.clientClosedRequest.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.clientClosedRequest.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.clientClosedRequest.isClientErrorHttpStatusCode,
+            isTrue,
+          );
+          expect(
+            HttpStatus.clientClosedRequest.isServerErrorHttpStatusCode,
+            isFalse,
+          );
         });
       });
-      group('5xx Server Error', () {
+      group('5xx Server Error -', () {
         test('500 Internal Server Error', () {
           expect(
             HttpStatus.internalServerError.code,
@@ -1010,6 +1694,26 @@ void main() {
             HttpStatus.code500InternalServerError,
             HttpStatus.internalServerError,
           );
+          expect(
+            HttpStatus.internalServerError.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.internalServerError.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.internalServerError.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.internalServerError.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.internalServerError.isServerErrorHttpStatusCode,
+            isTrue,
+          );
         });
         test('501 Not Implemented', () {
           expect(
@@ -1025,6 +1729,17 @@ void main() {
             ),
           );
           expect(HttpStatus.code501NotImplemented, HttpStatus.notImplemented);
+          expect(
+            HttpStatus.notImplemented.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.notImplemented.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.notImplemented.isRedirectHttpStatusCode, isFalse);
+          expect(
+            HttpStatus.notImplemented.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.notImplemented.isServerErrorHttpStatusCode, isTrue);
         });
         test('502 Bad Gateway', () {
           expect(HttpStatus.badGateway.code, equals(HttpStatusCode.badGateway));
@@ -1038,6 +1753,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code502BadGateway, HttpStatus.badGateway);
+          expect(HttpStatus.badGateway.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.badGateway.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.badGateway.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.badGateway.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.badGateway.isServerErrorHttpStatusCode, isTrue);
         });
         test('503 Service Unavailable', () {
           expect(
@@ -1060,6 +1780,26 @@ void main() {
             HttpStatus.code503ServiceUnavailable,
             HttpStatus.serviceUnavailable,
           );
+          expect(
+            HttpStatus.serviceUnavailable.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.serviceUnavailable.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.serviceUnavailable.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.serviceUnavailable.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.serviceUnavailable.isServerErrorHttpStatusCode,
+            isTrue,
+          );
         });
         test('504 Gateway Timeout', () {
           expect(
@@ -1076,6 +1816,17 @@ void main() {
             ),
           );
           expect(HttpStatus.code504GatewayTimeout, HttpStatus.gatewayTimeout);
+          expect(
+            HttpStatus.gatewayTimeout.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.gatewayTimeout.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.gatewayTimeout.isRedirectHttpStatusCode, isFalse);
+          expect(
+            HttpStatus.gatewayTimeout.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(HttpStatus.gatewayTimeout.isServerErrorHttpStatusCode, isTrue);
         });
         test('505 HTTP Version Not Supported', () {
           expect(
@@ -1096,6 +1847,26 @@ void main() {
           expect(
             HttpStatus.code505HttpVersionNotSupported,
             HttpStatus.httpVersionNotSupported,
+          );
+          expect(
+            HttpStatus.httpVersionNotSupported.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.httpVersionNotSupported.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.httpVersionNotSupported.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.httpVersionNotSupported.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.httpVersionNotSupported.isServerErrorHttpStatusCode,
+            isTrue,
           );
         });
         test('506 Variant Also Negotiates', () {
@@ -1120,6 +1891,26 @@ void main() {
             HttpStatus.code506VariantAlsoNegotiates,
             HttpStatus.variantAlsoNegotiates,
           );
+          expect(
+            HttpStatus.variantAlsoNegotiates.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.variantAlsoNegotiates.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.variantAlsoNegotiates.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.variantAlsoNegotiates.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.variantAlsoNegotiates.isServerErrorHttpStatusCode,
+            isTrue,
+          );
         });
         test('507 Insufficient Storage', () {
           expect(
@@ -1142,6 +1933,26 @@ void main() {
             HttpStatus.code507InsufficientStorage,
             HttpStatus.insufficientStorage,
           );
+          expect(
+            HttpStatus.insufficientStorage.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.insufficientStorage.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.insufficientStorage.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.insufficientStorage.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.insufficientStorage.isServerErrorHttpStatusCode,
+            isTrue,
+          );
         });
         test('508 Loop Detected', () {
           expect(
@@ -1159,6 +1970,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code508LoopDetected, HttpStatus.loopDetected);
+          expect(HttpStatus.loopDetected.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.loopDetected.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.loopDetected.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.loopDetected.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.loopDetected.isServerErrorHttpStatusCode, isTrue);
         });
         test('510 Not Extended', () {
           expect(
@@ -1175,6 +1991,11 @@ void main() {
             ),
           );
           expect(HttpStatus.code510NotExtended, HttpStatus.notExtended);
+          expect(HttpStatus.notExtended.isInformationHttpStatusCode, isFalse);
+          expect(HttpStatus.notExtended.isSuccessfulHttpStatusCode, isFalse);
+          expect(HttpStatus.notExtended.isRedirectHttpStatusCode, isFalse);
+          expect(HttpStatus.notExtended.isClientErrorHttpStatusCode, isFalse);
+          expect(HttpStatus.notExtended.isServerErrorHttpStatusCode, isTrue);
         });
         test('511 Network Authentication Required', () {
           expect(
@@ -1192,6 +2013,29 @@ void main() {
           expect(
             HttpStatus.code511NetworkAuthenticationRequired,
             HttpStatus.networkAuthenticationRequired,
+          );
+          expect(
+            HttpStatus
+                .networkAuthenticationRequired.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.networkAuthenticationRequired.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.networkAuthenticationRequired.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus
+                .networkAuthenticationRequired.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus
+                .networkAuthenticationRequired.isServerErrorHttpStatusCode,
+            isTrue,
           );
         });
         test('599 Network Connect Timeout Error', () {
@@ -1214,6 +2058,26 @@ void main() {
           expect(
             HttpStatus.code599NetworkConnectTimeoutError,
             HttpStatus.networkConnectTimeoutError,
+          );
+          expect(
+            HttpStatus.networkConnectTimeoutError.isInformationHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.networkConnectTimeoutError.isSuccessfulHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.networkConnectTimeoutError.isRedirectHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.networkConnectTimeoutError.isClientErrorHttpStatusCode,
+            isFalse,
+          );
+          expect(
+            HttpStatus.networkConnectTimeoutError.isServerErrorHttpStatusCode,
+            isTrue,
           );
         });
       });
@@ -1668,6 +2532,15 @@ void main() {
         HttpStatus.fromCode(HttpStatusCode.networkConnectTimeoutError),
         equals(HttpStatus.networkConnectTimeoutError),
       );
+    });
+    test('fromCode constructor returns correct check methods', () {
+      final HttpStatus httpStatus = HttpStatus.fromCode(599);
+      expect(httpStatus, equals(HttpStatus.networkConnectTimeoutError));
+      expect(httpStatus.isInformationHttpStatusCode, isFalse);
+      expect(httpStatus.isSuccessfulHttpStatusCode, isFalse);
+      expect(httpStatus.isRedirectHttpStatusCode, isFalse);
+      expect(httpStatus.isClientErrorHttpStatusCode, isFalse);
+      expect(httpStatus.isServerErrorHttpStatusCode, isTrue);
     });
   });
 }


### PR DESCRIPTION
This commit adds new methods to the `HttpStatus` class that allow checking if a given HTTP status code falls within specific ranges. The added methods include `isInformationHttpStatusCode`, `isSuccessfulHttpStatusCode`, `isRedirectHttpStatusCode`, `isClientErrorHttpStatusCode`, and `isServerErrorHttpStatusCode`. These methods will be useful for determining the category of an HTTP status code without having to manually compare it against each range.
