### PR TITLE
fix(workflows): Update Dart setup version and package dependencies

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: dart-lang/setup-dart@v1.6.2
+      - uses: dart-lang/setup-dart@v1.6.4
         with:
           sdk: ${{ matrix.channel }}
 
@@ -36,7 +36,7 @@ jobs:
         # --set-exit-if-changed stops execution if the any code is not well formatted
         # --output=none prints files which needs to be formatted
 
-        # Checks for Symantic errors. Can be configured using analysis_options.yaml
+        # Checks for Semantic errors. Can be configured using analysis_options.yaml
       - name: Analyze project source
         run: dart analyze --fatal-infos
         # optionally use --fatal-warnings to stop execution if any warnings are found
@@ -47,7 +47,7 @@ jobs:
           dart pub global run coverage:test_with_coverage
 
       - name: Check Code Coverage
-        uses: VeryGoodOpenSource/very_good_coverage@v2
+        uses: VeryGoodOpenSource/very_good_coverage@v3
         with:
           path: "./coverage/lcov.info"
           min_coverage: 100

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [3.3.2] - 2024-05-03
+
+### Fixed - 3.3.2
+
+- Updated the Dart setup version in workflow to v1.6.4 and dev dependencies versions for dart_code_linter to v1.1.3 and test to v1.25.4, also fixed a typo.
+
 ## [3.3.1] - 2024-02-26
 
 ### Fixed - 3.3.1

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -53,7 +53,7 @@ linter:
     - join_return_with_assignment
     - library_prefixes
     # - lines_longer_than_80_chars
-    # - omit_local_variable_types # confilict always_specify_types
+    # - omit_local_variable_types # conflict always_specify_types
     - one_member_abstracts
     - only_throw_errors
     - package_api_docs

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: http_status
 description: Constants enumerating the HTTP status codes in Dart. All status codes defined in RFC1945 (HTTP/1.0, RFC2616 (HTTP/1.1), and RFC2518 (WebDAV) are supported.
-version: 3.3.1
+version: 3.3.2
 repository: https://github.com/DartForge/http_status
 issue_tracker: https://github.com/DartForge/http_status/issues
 homepage: https://github.com/DartForge/http_status
@@ -18,6 +18,6 @@ dependencies:
 
 dev_dependencies:
   coverage: ^1.7.2
-  dart_code_linter: ^1.1.2
+  dart_code_linter: ^1.1.3
   lints: ^3.0.0
-  test: ^1.25.2
+  test: ^1.25.4


### PR DESCRIPTION
Updated the Dart setup version in workflows to v1.6.4 and dev dependencies versions for dart_code_linter to v1.1.3 and test to v1.25.4, also fixed some typos
